### PR TITLE
feat: Use loaded modules to access code from Joggers

### DIFF
--- a/docs/src/ci.md
+++ b/docs/src/ci.md
@@ -36,16 +36,13 @@ PkgJogger will create a temporary environment with the following:
 
 1) Instantiate the current package
 2) If found, instantiate `benchmark/Project.toml` and add to the `LOAD_PATH`
-3) Add PkgJogger, BenchmarkTools and Revise, while preserving the resolved manifest
+3) Add PkgJogger while preserving the resolved manifest
 4) Remove `@stdlib` and `@v#.#` from the `LOAD_PATH`
 
 This results in an isolated environment with the following properties:
 
 - PkgJogger does not dictate package resolution; the benchmarked package does
-- Packages not explicitly added by `Project.toml`, `benchmark/Project.toml` or
-  PkgJogger are unavailable
-
-See [`PkgJogger.JOGGER_PKGS`](@ref) for the exact list of packages added by PkgJogger
+- Packages not explicitly added by `Project.toml` or `benchmark/Project.toml`
 
 ## Reference
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,9 +8,6 @@ CurrentModule = PkgJogger
 
 PkgJogger makes benchmarking easy by providing a framework for running [BenchmarkTool.jl](https://github.com/JuliaCI/BenchmarkTools.jl) benchmarks without the boilerplate.
 
-> PkgJogger assumes that Revise and BenchmarkTools are loadable from the current
-> environment
-
 ## Just write benchmarks
 
 Create a `benchmark/bench_*.jl` file, define a `suite` and go!

--- a/src/PkgJogger.jl
+++ b/src/PkgJogger.jl
@@ -2,6 +2,7 @@ module PkgJogger
 
 using MacroTools
 using BenchmarkTools
+using Revise
 using CodecZlib
 using JSON
 using Pkg
@@ -10,15 +11,16 @@ using Dates
 
 export @jog
 
+import Base: PkgId
 """
-Additional Packages that are required by modules created with [`@jog`](@ref)
+Packages that are required by modules created with [`@jog`](@ref)
 
-[`PkgJogger.ci`](@ref) will add these to the benchmarking environment automatically
+Generated modules will access these via `Base.loaded_modules`
 """
 const JOGGER_PKGS = [
-    PackageSpec(name="PkgJogger", uuid="10150987-6cc1-4b76-abee-b1c1cbd91c01", path=dirname(@__DIR__)),
-    PackageSpec(name="BenchmarkTools", uuid="6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"),
-    PackageSpec(name="Revise", uuid="295af30f-e4ad-537b-8983-00126c2a3abe"),
+    Base.identify_package(@__MODULE__, string(@__MODULE__)),
+    PkgId(UUID("6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"), "BenchmarkTools"),
+    PkgId(UUID("295af30f-e4ad-537b-8983-00126c2a3abe"), "Revise"),
 ]
 
 include("dispatch.jl")

--- a/src/jogger.jl
+++ b/src/jogger.jl
@@ -42,7 +42,7 @@ macro jog(pkg)
     using_statements = Expr[]
     for pkg in JOGGER_PKGS
         pkgname = Symbol(pkg.name)
-        push!(using_statements, :(using $pkgname))
+        push!(using_statements, :(const $pkgname = Base.loaded_modules[$pkg]))
     end
 
     # Generate modules
@@ -85,7 +85,7 @@ macro jog(pkg)
             Gets the BenchmarkTools suite for $($pkg)
             """
             function suite()
-                suite = BenchmarkGroup()
+                suite = BenchmarkTools.BenchmarkGroup()
                 for (n, m) in zip([$(string.(benchmarks)...)], [$(benchmarks...)])
                     suite[n] = m.suite
                 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -56,12 +56,19 @@ function sandbox(f, pkg, load_path)
     current_project = Pkg.project()
     current_load_path = Base.LOAD_PATH
 
+    # Construct PackageSpec for self
+    self = PackageSpec(
+        name = JOGGER_PKGS[1].name,
+        uuid = JOGGER_PKGS[1].uuid,
+        path = dirname(dirname(pathof(@__MODULE__))),
+    )
+
     # Build temporary environment
-    # Add the project being benchmarked, then JOGGER_PKGS restricted to existing
-    # manifest. Ie. The benchmarked projects drives compat not PkgJogger
+    # Add the project being benchmarked, then PkgJogger restricted to existing
+    # manifest. Ie. The benchmarked projects drives manifest resolution, not PkgJogger
     Pkg.activate(;temp=true)
     Pkg.develop(pkg; io=devnull)
-    Pkg.add(JOGGER_PKGS; preserve=PRESERVE_ALL, io=devnull)
+    Pkg.add(self; preserve=PRESERVE_ALL, io=devnull)
     Pkg.instantiate(; io=devnull)
 
     # Update LOAD_PATH

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,15 @@ using SafeTestsets
 using PkgJogger
 
 @testset "PkgJogger.jl" begin
+    # Check that all modules listed in PkgJogger.JOGGER_PKGS are loaded
+    # Do this first so later loadings don't pollute loaded_modules
+    @testset "Loaded Modules" begin
+        @testset "Check $(m.name) was loaded" for m in PkgJogger.JOGGER_PKGS
+            @test haskey(Base.loaded_modules, m)
+        end
+    end
+
+    # Run the rest of the unit testing suite
     @safetestset "Smoke Tests" begin include("smoke.jl") end
     @safetestset "CI Workflow" begin include("ci.jl") end
 end


### PR DESCRIPTION
Prior versions required that JOGGER_PKGS could be loaded from Main
This fixes that by getting them from `Base.loaded_modules`

Added test to verify that we do load (via `using`) all packages in
JOGGER_PKGS