### PR TITLE
feat: Add tune!(group, ref) for retuning suites

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -5,6 +5,7 @@ PkgJogger.benchmark_dir
 PkgJogger.locate_benchmarks
 PkgJogger.judge
 PkgJogger.test_benchmarks
+PkgJogger.tune!
 ```
 
 ## Internal

--- a/test/smoke.jl
+++ b/test/smoke.jl
@@ -48,6 +48,13 @@ include("utils.jl")
         @test_throws AssertionError JogExample.load_benchmarks(UUIDs.uuid4())
     end
 
+    # Test Retuning
+    @testset "Reusing tune! results" begin
+        test_benchmark(JogExample.benchmark(ref = r), r)
+        test_benchmark(JogExample.benchmark(ref = get_uuid(file)), r)
+        test_benchmark(JogExample.benchmark(ref = file), r)
+    end
+
     # Test Judging
     @test_nowarn JogExample.judge(file, file)
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -52,3 +52,20 @@ function get_uuid(filename)
     splitpath(filename)[end] |> x -> split(x, ".")[1]
 end
 
+"""
+    test_benchmark(target::BenchmarkGroup, ref)
+
+Checks that target and ref are from equivalent benchmarking suite
+"""
+function test_benchmark(target, ref::BenchmarkGroup)
+    @test typeof(target) <: BenchmarkGroup
+    @test isempty(setdiff(keys(target), keys(ref)))
+    map(test_benchmark, target, ref)
+end
+test_benchmark(target, ref) = @test typeof(target) <: typeof(ref)
+function test_benchmark(target, ref::BenchmarkTools.Trial)
+    @test typeof(target) <: BenchmarkTools.Trial
+    @test params(target) == params(ref)
+end
+
+


### PR DESCRIPTION
Adds a method for reusing an existing suite tune, and only tuning new benchmarks

Also added benchmark(..., ref=suite_id) to  use the reference suite when
tuning the current suite

(cherry picked from commit 50aaabd6aef92ad1af0deb585701d5262d876d3a)

Fixes #18 