### PR TITLE
Breaking: Switch to BSON for storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Manifest.toml
 /docs/build/
 /benchmark/trial/
 *.json.gz
+*.bson.gz

--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,10 @@
 name = "PkgJogger"
 uuid = "10150987-6cc1-4b76-abee-b1c1cbd91c01"
 authors = ["Alexius Wadell <awadell@gmail.com> and contributors"]
-version = "0.3.5"
+version = "0.4.0"
 
 [deps]
+BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
+BSON = "0.3"
 BenchmarkTools = "1"
 CodecZlib = "0.7"
 JSON = "0.21"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To get around the above, run `@jog PkgName` to get an updated jogger.
 
 ## Continuous Benchmarking Baked In!
 
-Install PkgJogger, run benchmarks, and save results to a `*.json.gz` with a
+Install PkgJogger, run benchmarks, and save results to a `*.bson.gz` with a
 one-line command.
 
 ```shell
@@ -77,7 +77,7 @@ What gets done:
 - Creates a [jogger](https://awadell1.github.io/PkgJogger.jl/stable/jogger/)
   to run the package's benchmarks.
 - Warmup, tune and run all benchmarks.
-- Save Benchmarking results and more to a compressed `*.json.gz` file.
+- Save Benchmarking results and more to a compressed `*.bson.gz` file.
 
 Or for a more lightweight option, use
 [`@test_bechmarks`](https://awadell1.github.io/PkgJogger.jl/stable/ci/#Testing-Benchmarks)

--- a/docs/src/io.md
+++ b/docs/src/io.md
@@ -11,6 +11,7 @@ These methods build on
   - System Information (Essentially everything in `Sys`)
   - Timestamp when the results get saved
   - Git Information, if run from a Git Repository
+  - The version of PkgJogger used to save the results
 
 Overall the resulting files are ~10x smaller, despite capturing additional information.
 
@@ -28,7 +29,7 @@ using PkgJogger
 @jog AwesomePkg
 results = JogAwesomePkg.benchmark()
 
-# Saves results to BENCH_DIR/trial/UUID.json.gz and returns the filename used
+# Saves results to BENCH_DIR/trial/UUID.bson.gz and returns the filename used
 JogAwesomePkg.save_benchmarks(results)
 
 # Or run and save the benchmarks in a single step, the filename saved to

--- a/src/PkgJogger.jl
+++ b/src/PkgJogger.jl
@@ -5,6 +5,7 @@ using BenchmarkTools
 using Revise
 using CodecZlib
 using JSON
+using BSON
 using Pkg
 using UUIDs
 using Dates
@@ -26,6 +27,10 @@ const JOGGER_PKGS = [
     PkgId(UUID("295af30f-e4ad-537b-8983-00126c2a3abe"), "Revise"),
     PkgId(UUID("cf7118a7-6976-5b1a-9a39-7adc72f591a4"), "UUIDs"),
 ]
+
+const PKG_JOGGER_VER = VersionNumber(
+    Base.parsed_toml(joinpath(@__DIR__, "..", "Project.toml"))["version"]
+)
 
 include("utils.jl")
 include("jogger.jl")

--- a/src/ci.jl
+++ b/src/ci.jl
@@ -223,14 +223,6 @@ end
 load_benchmarks(dir, s::Symbol) = load_benchmarks(dir, Val(s))
 
 # Load the latest benchmarking results
-function load_benchmarks(trial_dir::AbstractString, ::Val{:latest})
-    r = list_benchmarks(trial_dir)
-    @assert !isempty(r) "No benchmarking results found in $trial_dir"
-    latest = argmax(mtime, r)
-    return load_benchmarks(latest)
-end
-
-# Load the latest benchmarking results
 load_benchmarks(trial_dir::AbstractString, ::Val{:latest}) =
     load_benchmarks(argmax(mtime, list_benchmarks(trial_dir)))
 

--- a/src/jogger.jl
+++ b/src/jogger.jl
@@ -175,13 +175,37 @@ macro jog(pkg)
             Compares benchmarking results from `new` vs `old` for regressions/improvements
             using `metric` as a basis. Additional `kwargs` are passed to `BenchmarkTools.judge`
 
-            Identical to [`PkgJogger.judge`](@ref), but accepts UUIDs for `new` and `old`
+            Identical to [`PkgJogger.judge`](@ref), but accepts any identifier supported by
+            [`$($modname).load_benchmarks`](@ref)
+
+            ## Examples
+
+            ```julia
+            # Judge the latest results vs. the oldest
+            $($modname).judge(:latest, :oldest)
+            [...]
+            ```
+
+            ```julia
+            # Judge results by UUID
+            $($modname).judge("$(UUIDs.uuid4())", "$(UUIDs.uuid4())")
+            [...]
+            ```
+
+            ```julia
+            # Judge using the minimum, instead of the median, time
+            $($modname).judge("path/to/results.bson.gz", "$(UUIDs.uuid4())"; metric=minimum)
+            [...]
+            ```
+
             """
             function judge(new, old; kwargs...)
                 PkgJogger.judge(_get_benchmarks(new), _get_benchmarks(old); kwargs...)
             end
-            _get_benchmarks(b::AbstractString) = load_benchmarks(b)
-            _get_benchmarks(b) = PkgJogger._get_benchmarks(b)
+            _get_benchmarks(b) = load_benchmarks(b)
+            _get_benchmarks(b::Dict) = PkgJogger._get_benchmarks(b)
+            _get_benchmarks(b::BenchmarkTools.BenchmarkGroup) = b
+
         end
     end
 end

--- a/src/jogger.jl
+++ b/src/jogger.jl
@@ -157,22 +157,17 @@ macro jog(pkg)
             end
 
             """
-                load_benchmarks(filename::String)::Dict
-                load_benchmarks(uuid::String)::Dict
-                load_benchmarks(uuid::UUID)::Dict
+                load_benchmarks(id)::Dict
 
-            Loads benchmarking results for $($pkg) from `BENCHMARK_DIR/trial`
+            Loads benchmarking results for $($pkg) from `BENCHMARK_DIR/trial` based on `id`.
+            The following are supported `id` types:
+
+                - `filename::String`: Loads results from `filename`
+                - `uuid::Union{String, UUID}`: Loads results with the given UUID
+                - `:latest` loads the latest (By mtime) results from `BENCHMARK_DIR/trial`
+                - `:oldest` loads the oldest (By mtime) results from `BENCHMARK_DIR/trial`
             """
-            load_benchmarks(uuid::UUIDs.UUID) = load_benchmarks(string(uuid))
-            function load_benchmarks(uuid::AbstractString)
-                # Check if input is a filename
-                isfile(uuid) && return PkgJogger.load_benchmarks(uuid)
-
-                # Check if a valid benchmark uuid
-                path = joinpath(BENCHMARK_DIR, "trial", uuid * ".json.gz")
-                @assert isfile(path) "Missing benchmarking results for $uuid, expected path: $path"
-                PkgJogger.load_benchmarks(path)
-            end
+            load_benchmarks(id) = PkgJogger.load_benchmarks(joinpath(BENCHMARK_DIR, "trial"), id)
 
             """
                 judge(new, old; metric=Statistics.median, kwargs...)

--- a/src/jogger.jl
+++ b/src/jogger.jl
@@ -175,13 +175,33 @@ macro jog(pkg)
             Compares benchmarking results from `new` vs `old` for regressions/improvements
             using `metric` as a basis. Additional `kwargs` are passed to `BenchmarkTools.judge`
 
-            Identical to [`PkgJogger.judge`](@ref), but accepts UUIDs for `new` and `old`
+            Identical to [`PkgJogger.judge`](@ref), but accepts any identifier supported by
+            [`$($modname).load_benchmarks`](@ref)
+
+            ## Examples
+
+            ```julia
+            # Judge the latest results vs. the oldest
+            $($modname).judge(:latest, :oldest)
+            [...]
+            ```
+
+            ```julia
+            # Judge results by UUID
+            $($modname).judge("$(UUIDs.uuid4())", "$(UUIDs.uuid4())")
+            [...]
+            ```
+
+            ```julia
+            # Judge using the minimum, instead of the median, time
+            $($modname).judge("path/to/results.json.gz", "$(UUIDs.uuid4())"; metric=minimum)
+            [...]
+            ```
+
             """
             function judge(new, old; kwargs...)
-                PkgJogger.judge(_get_benchmarks(new), _get_benchmarks(old); kwargs...)
+                PkgJogger.judge(load_benchmarks(new), load_benchmarks(old); kwargs...)
             end
-            _get_benchmarks(b::AbstractString) = load_benchmarks(b)
-            _get_benchmarks(b) = PkgJogger._get_benchmarks(b)
         end
     end
 end

--- a/src/jogger.jl
+++ b/src/jogger.jl
@@ -175,33 +175,13 @@ macro jog(pkg)
             Compares benchmarking results from `new` vs `old` for regressions/improvements
             using `metric` as a basis. Additional `kwargs` are passed to `BenchmarkTools.judge`
 
-            Identical to [`PkgJogger.judge`](@ref), but accepts any identifier supported by
-            [`$($modname).load_benchmarks`](@ref)
-
-            ## Examples
-
-            ```julia
-            # Judge the latest results vs. the oldest
-            $($modname).judge(:latest, :oldest)
-            [...]
-            ```
-
-            ```julia
-            # Judge results by UUID
-            $($modname).judge("$(UUIDs.uuid4())", "$(UUIDs.uuid4())")
-            [...]
-            ```
-
-            ```julia
-            # Judge using the minimum, instead of the median, time
-            $($modname).judge("path/to/results.json.gz", "$(UUIDs.uuid4())"; metric=minimum)
-            [...]
-            ```
-
+            Identical to [`PkgJogger.judge`](@ref), but accepts UUIDs for `new` and `old`
             """
             function judge(new, old; kwargs...)
-                PkgJogger.judge(load_benchmarks(new), load_benchmarks(old); kwargs...)
+                PkgJogger.judge(_get_benchmarks(new), _get_benchmarks(old); kwargs...)
             end
+            _get_benchmarks(b::AbstractString) = load_benchmarks(b)
+            _get_benchmarks(b) = PkgJogger._get_benchmarks(b)
         end
     end
 end

--- a/src/jogger.jl
+++ b/src/jogger.jl
@@ -143,7 +143,7 @@ macro jog(pkg)
             """
                 save_benchmarks(results::BenchmarkGroup)::String
 
-            Saves benchmarking results for $($pkg) to `BENCHMARK_DIR/trial/uuid4().json.gz`.
+            Saves benchmarking results for $($pkg) to `BENCHMARK_DIR/trial/uuid4().bson.gz`.
 
             Returns the path to the saved results
 
@@ -151,7 +151,7 @@ macro jog(pkg)
             [`$($modname).load_benchmarks(uuid)`](@ref)
             """
             function save_benchmarks(results)
-                filename = joinpath(BENCHMARK_DIR, "trial", "$(UUIDs.uuid4()).json.gz")
+                filename = joinpath(BENCHMARK_DIR, "trial", "$(UUIDs.uuid4()).bson.gz")
                 PkgJogger.save_benchmarks(filename, results)
                 filename
             end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -158,30 +158,108 @@ end
 Tunes a BenchmarkGroup, only tunning benchmarks not found in `ref`, otherwise reuse tuning
 results from the reference BenchmarkGroup, by copying over all benchmark parameters from `ref`.
 
+Tunning is handled by `BenchmarkTools.tune!`
+
 This can reduce benchmarking runtimes significantly by only tuning new benchmarks. But does
 ignore the following:
-    - Changes to benchmarking parameters (ie. memory_tolerance) between `group` and `ref`
-    - Significant changes in performance, such that re-tunning is warranted
-    - Other changes (ie. changing machines), such that re-tunning is warranted
+
+- Changes to benchmarking parameters (ie. memory_tolerance) between `group` and `ref`
+- Significant changes in performance, such that re-tunning is warranted
+- Other changes (ie. changing machines), such that re-tunning is warranted
+
+Benchmarks are in `group` and `ref` are matched after serializing their keys. This is to
+support reusing tunes from a saved run. As the key `["bench_foo.jl", 0.1]` serializes to
+`["bench_foo.jl", "0.1"]`. In order to avoid potential conflict, tuning results are only
+used iff:
+
+- `ref` has a key that serializes to a matching key (i.e. `["bench_foo.jl", "0.1"]`)
+- No other key in `ref` or `group` serializes to the same key
+
+> For example, If `ref` contained both `["bench_foo.jl", 0.1]` and `["bench_foo.jl", "0.1"]`, then
+> neither would be used, as there is no way to distinguish between the two, post-serialization.
 """
 function tune!(group::BenchmarkTools.BenchmarkGroup, ref::BenchmarkTools.BenchmarkGroup; kwargs...)
-    ids = keys(group) |> collect
-    ref_ids = keys(ref) |> collect
+    # Get the benchmark trials from each set
+    group_leaves  = _resolve_leaves(group)
+    ref_leaves = _resolve_leaves(ref)
 
-    # Tune new benchmarks
-    for id in setdiff(ids, ref_ids)
-        tune!(group[id]; kwargs...)
+    # Only reuse tuning results that can be uniquely identified
+    _injective!(group_leaves, ref_leaves)
+    reuse_leave, retune_leaves = group_leaves
+    ref_injective = first(ref_leaves)
+
+    # Only reuse tuning results that can be uniquely identified
+    for (k, v) in retune_leaves
+        BenchmarkTools.tune!(v; kwargs...)
     end
 
     # Reuse tunning from prior benchmarks
-    for id in intersect(ids, ref_ids)
-        tune!(group[id], ref[id]; kwargs...)
+    for (k, v) in reuse_leave
+        v.params = copy(ref_injective[k].params)
     end
 
     return group
 end
-tune!(b::BenchmarkTools.Benchmark, ref; kwargs...) = b.params = copy(ref.params)
-tune!(group::BenchmarkTools.BenchmarkGroup, ::Nothing; kwargs...) = tune!(group; kwargs...)
+
 tune!(group::BenchmarkTools.BenchmarkGroup; kwargs...) = BenchmarkTools.tune!(group; kwargs...)
-tune!(group::BenchmarkTools.BenchmarkGroup, ref::Dict; kwargs...) = tune!(group, get(ref, "benchmarks", nothing); kwargs...)
 tune!(group::BenchmarkTools.BenchmarkGroup, ref; kwargs...) = tune!(group, load_benchmarks(ref); kwargs...)
+tune!(group::BenchmarkTools.BenchmarkGroup, ref::Dict; kwargs...) = tune!(group, get(ref, "benchmarks", nothing); kwargs...)
+tune!(group::BenchmarkTools.BenchmarkGroup, ::Nothing; kwargs...) = tune!(group; kwargs...)
+
+"""
+    injective, non_injective = _resolve_leaves(b::BenchmarkGroup)
+
+Given a benchmark group, split it's leaves into an injective and non-injective set. Leaves
+in the injective are can be uniquely identified after their key has been stringified
+
+For example, `0.1` and `"0.2"` can be uniquely identified after being stringified `"0.1" !=
+"0.2"`. But, `0.1` and `"0.1"` cannot be uniquely identified after being stringified `"0.1"
+== "0.1"`.
+
+This function splits the leaves into an injective set (Where stringifing doesn't result in
+conflicts) and an non_injective set which does.
+"""
+function _resolve_leaves(group::BenchmarkTools.BenchmarkGroup)
+    # Convert benchmark keys to vectors of strings
+    bench_leaves = leaves(group)
+    injective = Dict{Vector{String}, Any}()
+    non_injective = Dict{Vector{String}, Vector{Any}}()
+    for b in bench_leaves
+        norm_key = string.(first(b))
+        maybe_injective = !haskey(non_injective, norm_key)
+        if !haskey(injective, norm_key) && maybe_injective
+            # Unique mapping from key to string encoded key
+            injective[norm_key] = last(b)
+        else
+            # If the key was previously injective, pop it from the injective set and
+            # add it to the non-injective set
+            if maybe_injective
+                non_injective[norm_key] = [pop!(injective, norm_key)]
+            end
+
+            # And the new non-injective benchmark key
+            push!(non_injective[norm_key], last(b))
+        end
+    end
+
+    # Warn if any key is non-injective
+    if !isempty(non_injective)
+        @warn "Benchmark Keys are not-unique after serializing" keys(non_injective)
+    end
+    return injective, non_injective
+end
+
+function _injective!(a, b)
+    a_inject, a_non_inject = a
+    b_inject, b_non_inject = b
+
+    # For each uniquely identifiable key in a, check if there is a unique item in b
+    for key in keys(a_inject)
+        if haskey(b_non_inject, key) || !haskey(b_inject, key)
+            # Non-unique mapping from a -> b
+            a_non_inject[key] = [pop!(a_inject, key)]
+        end
+    end
+    return nothing
+end
+

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,9 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"

--- a/test/backward_compat.jl
+++ b/test/backward_compat.jl
@@ -1,0 +1,48 @@
+using Test
+using JSON
+using PkgJogger
+using Example
+using CodecZlib
+using Dates
+
+include("utils.jl")
+
+# Get Benchmarking results
+@jog Example
+b = JogExample.benchmark()
+
+# Save using JSON
+function save_benchmarks(filename, results::BenchmarkTools.BenchmarkGroup)
+    # Collect system information to save
+    mkpath(dirname(filename))
+    out = Dict(
+        "julia" => PkgJogger.julia_info(),
+        "system" => PkgJogger.system_info(),
+        "datetime" => string(Dates.now()),
+        "benchmarks" => results,
+        "git" => PkgJogger.git_info(filename),
+    )
+
+    # Write benchmark to disk
+    open(GzipCompressorStream, filename, "w") do io
+        JSON.print(io, out)
+    end
+end
+
+@testset "Compat *.json.gz" begin
+    f = tempname(; cleanup=false) * ".json.gz"
+    finalizer(rm, f)
+    save_benchmarks(f, b)
+
+    # Check that the deprecated warming is logged
+    local b2
+    @test_logs (:warn, r"Legacy `\*\.json\.gz` format is deprecated.*") begin
+        b2 = JogExample.load_benchmarks(f)
+    end
+
+    # Check that benchmarks are still there
+    @test b2 isa Dict
+    @test haskey(b2, "benchmarks")
+    @test b2["benchmarks"] isa BenchmarkTools.BenchmarkGroup
+end
+

--- a/test/ci.jl
+++ b/test/ci.jl
@@ -77,6 +77,7 @@ end
 @testset "Example.jl" begin
     project = joinpath(@__DIR__, "Example.jl")
     results = run_ci_workflow(project)
+    cleanup_example()
 
     # Check timer results are decent (sleep isn't very accurate)
     isapprox((time∘minimum)(results["benchmarks"][["bench_timer.jl", "1ms"]]), 1e6; atol=3e6)

--- a/test/judging.jl
+++ b/test/judging.jl
@@ -29,3 +29,5 @@ end
 @testset "Test JogPkgName.judge" for (n, o) in Iterators.product(new, old)
     test_judge(JogExample.judge, n, o)
 end
+
+cleanup_example()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ using PkgJogger
     @safetestset "CI Workflow" begin include("ci.jl") end
     @safetestset "Locate Benchmarks" begin include("locate_benchmarks.jl") end
     @safetestset "Tuning Suites" begin include("tune.jl") end
+    @safetestset "Backwards Compatibility" begin include("backward_compat.jl") end
     @safetestset "Doc Tests" begin
         using PkgJogger
         using Documenter

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,3 +29,6 @@ using PkgJogger
         doctest(PkgJogger)
     end
 end
+
+# Tests should cleanup trials after finishing
+@test !isdir(joinpath(@__DIR__, "Example.jl", "benchmark", "trial"))

--- a/test/smoke.jl
+++ b/test/smoke.jl
@@ -45,8 +45,8 @@ include("utils.jl")
         @test r2 == r3 == r4 == r5
 
         # Check that we error for invalid uuids
-        @test_throws AssertionError JogExample.load_benchmarks("not-a-uuid")
-        @test_throws AssertionError JogExample.load_benchmarks(UUIDs.uuid4())
+        @test_throws ErrorException JogExample.load_benchmarks("not-a-uuid")
+        @test_throws ErrorException JogExample.load_benchmarks(UUIDs.uuid4())
         @test_throws MethodError JogExample.load_benchmarks(:not_a_valid_option)
     end
 

--- a/test/smoke.jl
+++ b/test/smoke.jl
@@ -89,6 +89,7 @@ end
 @testset "benchmark and save" begin
     @jog Example
     @test @isdefined JogExample
+    cleanup_example()
 
     logger = TestLogger()
     with_logger(logger) do
@@ -104,13 +105,22 @@ end
     r = PkgJogger.load_benchmarks(filename)
     test_loaded_results(r)
 
-    # Check that :latest returns the same results
+    # Check that :latest and :oldest returns the same results
+    # Currently only have one result Saved
     r_latest = JogExample.load_benchmarks(:latest)
-    test_loaded_results(r_latest)
-    @test r == r_latest
-
-    # Check that :oldest returns a different result
     r_oldest = JogExample.load_benchmarks(:oldest)
-    test_loaded_results(r_oldest)
-    @test r != r_oldest
+    @test r == r_latest == r_oldest
+
+    # Check that :latest and :oldest return different results
+    # Now have two results saved, so :latest and :oldest should return different results
+    # Underlying benchmarks should still be the same, as we are using the same results
+    JogExample.save_benchmarks(r["benchmarks"])
+    r_latest = JogExample.load_benchmarks(:latest)
+    r_oldest = JogExample.load_benchmarks(:oldest)
+    @test r != r_latest
+    @test r == r_oldest
+    @test r["benchmarks"] == r_latest["benchmarks"] == r_oldest["benchmarks"]
+
 end
+
+cleanup_example()

--- a/test/smoke.jl
+++ b/test/smoke.jl
@@ -38,14 +38,16 @@ include("utils.jl")
         uuid = get_uuid(file)
         r3 = JogExample.load_benchmarks(uuid)
         r4 = JogExample.load_benchmarks(UUID(uuid))
+        r5 = JogExample.load_benchmarks(:latest)
         @test r3 == r4
         @test r3["benchmarks"] == r
         @test r4["benchmarks"] == r
-        @test r2 == r3 == r4
+        @test r2 == r3 == r4 == r5
 
         # Check that we error for invalid uuids
         @test_throws AssertionError JogExample.load_benchmarks("not-a-uuid")
         @test_throws AssertionError JogExample.load_benchmarks(UUIDs.uuid4())
+        @test_throws MethodError JogExample.load_benchmarks(:not_a_valid_option)
     end
 
     # Test Retuning
@@ -53,6 +55,8 @@ include("utils.jl")
         test_benchmark(JogExample.benchmark(ref = r), r)
         test_benchmark(JogExample.benchmark(ref = get_uuid(file)), r)
         test_benchmark(JogExample.benchmark(ref = file), r)
+        test_benchmark(JogExample.benchmark(ref = :latest), r)
+        test_benchmark(JogExample.benchmark(ref = :oldest), r)
     end
 
     # Test Judging
@@ -99,4 +103,14 @@ end
     filename = match(r"\S*$", logger.logs[1].message).match
     r = PkgJogger.load_benchmarks(filename)
     test_loaded_results(r)
+
+    # Check that :latest returns the same results
+    r_latest = JogExample.load_benchmarks(:latest)
+    test_loaded_results(r_latest)
+    @test r == r_latest
+
+    # Check that :oldest returns a different result
+    r_oldest = JogExample.load_benchmarks(:oldest)
+    test_loaded_results(r_oldest)
+    @test r != r_oldest
 end

--- a/test/tune.jl
+++ b/test/tune.jl
@@ -70,7 +70,7 @@ end
     @testset "Fall back to BenchmarkTools.tune!" begin
         @test_tune PkgJogger.tune!(ref_suite()) ref_tune
         @test_tune PkgJogger.tune!(ref_suite(), nothing) ref_tune
-        @test_tune PkgJogger.tune!(ref_suite(), Dict()) ref_tune
+        @test_throws AssertionError PkgJogger.tune!(ref_suite(), Dict())
     end
 
     @testset "Reuse prior tune" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -88,3 +88,13 @@ function add_benchmark(pkg, path)
     suite = Set([[splitpath(path)..., "foo"]])
     return suite, cleanup
 end
+
+"""
+    cleanup_example()
+
+Remove generated files from Example.jl
+"""
+function cleanup_example()
+    example_dir = joinpath(PKG_JOGGER_PATH, "test", "Example.jl")
+    rm(joinpath("Example.jl", "benchmark", "trial"); force=true, recursive=true)
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -96,5 +96,22 @@ Remove generated files from Example.jl
 """
 function cleanup_example()
     example_dir = joinpath(PKG_JOGGER_PATH, "test", "Example.jl")
-    rm(joinpath("Example.jl", "benchmark", "trial"); force=true, recursive=true)
+    rm(joinpath(example_dir, "benchmark", "trial"); force=true, recursive=true)
+end
+
+import Base: ==
+"""
+    ==(a::Base.Sys.CPUinfo, b::Base.Sys.CPUinfo)
+
+Mark two CPUinfo objects as equal if all of their fields match
+"""
+function ==(a::Base.Sys.CPUinfo, b::Base.Sys.CPUinfo)
+    for f in propertynames(a)
+        af = getproperty(a, f)
+        bf = getproperty(b, f)
+        if af != bf
+            return false
+        end
+    end
+    return true
 end


### PR DESCRIPTION
While implementing `load_benchmarks(:latest)` it became apparent that stringifying everything before saving wasn't ideal (#45, #46, #43), and attempting to invert stringifying (35ed40a) started to balloon (Adding support for `judge` was getting hacky). So instead I've decided to switch to a serializer that wouldn't stringify everything.

- `Serialization.serialize` - Smallest file size of all methods. But lacks stability (by design) across versions and machines. While benchmarking results tend to lose value quickly, I do want to support judging between versions / across machines.
- [`JLD2`](https://github.com/JuliaIO/JLD2.jl) - Large file size, even when compressed
- [`JLD`](https://github.com/JuliaIO/JLD.jl) - Would add a dependency on HDF5, large file size, and slow
- [`JSON`](https://github.com/JuliaIO/JSON.jl) - Stringifies most data, mangling the keys for benchmark groups.

| Serializer | File Size [kB] | Save Time |
|---|---|---|
| JSON | 1.1 | 480 μs |
| Serialization | 1.2 | 130 μs |
| BSON | 1.8 | 1 ms |
| JLD2 | 3.8 | 670 μs |
| JLD | 5.1 | 6 ms |

> File Size are the saving the benchmarks of `test/Example.jl`. Save Time is the rounded min time to save a results dict without compression.

## Backwards compatibility 

PkgJogger v0.4 and later will save results using BSON to `*.bson.gz` files. Loading results with `load_benchmarks` from `*.json.gz` files is supported by PkgJogger v0.4, but will be removed in a future release. 

## Other Changes

This PR also adds support for `JogExample.load_benchmarks(:lastest)` and `JogExample.load_benchmarks(:oldest)` to load the most recent / oldest results from disk. The `:latest` and `:oldest` identifiers are supported by `judge` and `tune!`  as well.





