### PR TITLE
Missing tune!(::Benchmark,...)

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -183,7 +183,7 @@ end
 
 # Fallback to using BenchmarkTools's tuning if no reference is provided
 tune!(group::BenchmarkTools.BenchmarkGroup, ::Nothing; kwargs...) = tune!(group; kwargs...)
-tune!(group::BenchmarkTools.BenchmarkGroup; kwargs...) = BenchmarkTools.tune!(group; kwargs...)
+tune!(b; kwargs...) = BenchmarkTools.tune!(b; kwargs...)
 
 # If ref is not a BenchmarkGroup, attempt to get it based on the type
 tune!(group::BenchmarkTools.BenchmarkGroup, ref; kwargs...) = tune!(group, _get_benchmarks(ref); kwargs...)

--- a/test/judging.jl
+++ b/test/judging.jl
@@ -17,17 +17,38 @@ function test_judge(f, new, old)
     @inferred f(new, old)
     judgement = f(new, old)
     @test typeof(judgement) <: BenchmarkGroup
+    return judgement
 end
 
 # Run Benchmarks for testing
 new = gen_example()
 old = gen_example()
 
-@testset "Test PkgJogger.judge" for (n, o) in Iterators.product(new[1:3], old[1:3])
-    test_judge(PkgJogger.judge, n, o)
-end
-@testset "Test JogPkgName.judge" for (n, o) in Iterators.product(new, old)
+@testset "Test JogPkgName.judge($(typeof(n)), $(typeof(o)))" for (n, o) in Iterators.product(new, old)
     test_judge(JogExample.judge, n, o)
+end
+
+@testset "Missing Results - $(typeof(n))" for n in new
+    @testset "Empty Suite" begin
+        # Expect an empty judgement
+        judgement = test_judge(JogExample.judge, n, BenchmarkGroup())
+        isempty(judgement)
+    end
+    @testset "Missing Benchmark Judgement" begin
+        # Get a suite of results to modify
+        ref = deepcopy(first(new))
+        ref_leaves = first.(leaves(ref))
+
+        # Add a new Trial results
+        name, trial = first(leaves(ref))
+        name[end] = rand()
+        ref[name] = trial
+
+        # Expect the extra benchmark to be skipped
+        judgement = test_judge(JogExample.judge, n, ref)
+        judgement_leaves = first.(leaves(judgement))
+        @test Set(judgement_leaves) == Set(ref_leaves)
+    end
 end
 
 cleanup_example()


### PR DESCRIPTION
Retuning using a reference suite with missing benchmarks (ie. benchmarks added since the reference results) would error with:

```julia
Missing Reference Benchmark: Error During Test at /Users/alexwadell/.julia/dev/PkgJogger/test/tune.jl:78
  Got exception outside of a @test
  MethodError: no method matching tune!(::BenchmarkTools.Benchmark)
  Closest candidates are:
    tune!(::BenchmarkTools.Benchmark, ::Any; kwargs...) at ~/.julia/dev/PkgJogger/src/utils.jl:192
    tune!(::BenchmarkGroup; kwargs...) at ~/.julia/dev/PkgJogger/src/utils.jl:186
    tune!(::BenchmarkGroup, ::BenchmarkGroup; pad, kwargs...) at ~/.julia/dev/PkgJogger/src/utils.jl:171
    ...
  Stacktrace:
    [1] tune!(group::BenchmarkGroup, ref::BenchmarkGroup; pad::String, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
      @ PkgJogger ~/.julia/dev/PkgJogger/src/utils.jl:178
    [2] tune!(group::BenchmarkGroup, ref::BenchmarkGroup)
      @ PkgJogger ~/.julia/dev/PkgJogger/src/utils.jl:172
    [3] tune!(group::BenchmarkGroup, ref::BenchmarkGroup; pad::String, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
      @ PkgJogger ~/.julia/dev/PkgJogger/src/utils.jl:175
    [4] tune!(group::BenchmarkGroup, ref::BenchmarkGroup)
      @ PkgJogger ~/.julia/dev/PkgJogger/src/utils.jl:172
```

This adds test to trigger that condition, and the missing method.

This PR also adds tests to confirm that `Jogger.judge` is unaffected (See #45 )