### PR TITLE
Missing tune

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,7 @@ on:
   - pull_request
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/test/judging.jl
+++ b/test/judging.jl
@@ -42,7 +42,7 @@ end
         # Add a new Trial results
         name, trial = first(leaves(ref))
         name[end] = rand()
-        ref[name] = trial
+        ref[name] = deepcopy(trial)
 
         # Expect the extra benchmark to be skipped
         judgement = test_judge(JogExample.judge, n, ref)

--- a/test/judging.jl
+++ b/test/judging.jl
@@ -24,8 +24,12 @@ end
 new = gen_example()
 old = gen_example()
 
-@testset "Test JogPkgName.judge($(typeof(n)), $(typeof(o)))" for (n, o) in Iterators.product(new, old)
+@testset "JogPkgName.judge($(typeof(n)), $(typeof(o)))" for (n, o) in Iterators.product(new, old)
     test_judge(JogExample.judge, n, o)
+end
+
+@testset "PkgJogger.judge($(typeof(n)), $(typeof(o)))" for (n, o) in Iterators.product(new[1:3], old[1:3])
+    test_judge(PkgJogger.judge, n, o)
 end
 
 @testset "Missing Results - $(typeof(n))" for n in new

--- a/test/tune.jl
+++ b/test/tune.jl
@@ -82,7 +82,7 @@ end
             # Add a new benchmark to new_suite to be tunned
             n, b = first(leaves(new_suite))
             n[end] = rand()
-            new_suite[n] = b
+            new_suite[n] = deepcopy(b)
 
             # Everything except the new benchmark should be tuned
             r = PkgJogger.tune!(new_suite, ref)


### PR DESCRIPTION
(Take 2 on #50)

Retuning using a reference suite with missing benchmarks (ie. benchmarks added since the reference results) would error with:

```julia
Missing Reference Benchmark: Error During Test at /Users/alexwadell/.julia/dev/PkgJogger/test/tune.jl:78
  Got exception outside of a @test
  MethodError: no method matching tune!(::BenchmarkTools.Benchmark)
  Closest candidates are:
    tune!(::BenchmarkTools.Benchmark, ::Any; kwargs...) at ~/.julia/dev/PkgJogger/src/utils.jl:192
    tune!(::BenchmarkGroup; kwargs...) at ~/.julia/dev/PkgJogger/src/utils.jl:186
    tune!(::BenchmarkGroup, ::BenchmarkGroup; pad, kwargs...) at ~/.julia/dev/PkgJogger/src/utils.jl:171
    ...
  Stacktrace:
    [1] tune!(group::BenchmarkGroup, ref::BenchmarkGroup; pad::String, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
      @ PkgJogger ~/.julia/dev/PkgJogger/src/utils.jl:178
    [2] tune!(group::BenchmarkGroup, ref::BenchmarkGroup)
      @ PkgJogger ~/.julia/dev/PkgJogger/src/utils.jl:172
    [3] tune!(group::BenchmarkGroup, ref::BenchmarkGroup; pad::String, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
      @ PkgJogger ~/.julia/dev/PkgJogger/src/utils.jl:175
    [4] tune!(group::BenchmarkGroup, ref::BenchmarkGroup)
      @ PkgJogger ~/.julia/dev/PkgJogger/src/utils.jl:172
```

This adds test to trigger that condition, and the missing method.

This PR also adds tests to confirm that `Jogger.judge` is unaffected (See #45 )