### PR TITLE
Use Pkg.develop for PkgJogger in sandbox

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PkgJogger"
 uuid = "10150987-6cc1-4b76-abee-b1c1cbd91c01"
 authors = ["Alexius Wadell <awadell@gmail.com> and contributors"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"

--- a/src/ci.jl
+++ b/src/ci.jl
@@ -71,7 +71,7 @@ function sandbox(f, pkg)
         # Build up benchmarked environment
         Pkg.activate(temp_env; io=devnull)
         Pkg.develop(pkg; preserve=PRESERVE_NONE, io=devnull)
-        Pkg.add(self; preserve=PRESERVE_TIERED, io=devnull)
+        Pkg.develop(self; preserve=PRESERVE_TIERED, io=devnull)
         Pkg.instantiate(; io=devnull)
 
         # Strip LOAD_PATH to the temporary environment


### PR DESCRIPTION
- **fix: use Pkg.add to add PkgJogger to the sandbox**
- **Bump patch**
