### PR TITLE
Compat: minimize bounds (Revise ≥3.3, BSON ≥0.3.4); keep ranges wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 ## [Unreleased](https://github.com/awadell1/PkgJogger.jl/compare/v0.6.0...HEAD)
 
+- Compat: Revise ≥3.3; BSON ≥0.3.4
+
 ## [v0.6.0](https://github.com/awadell1/PkgJogger.jl/compare/v0.5.1...v0.6.0) - 2025-08-16
 
 - Added: define the public interface.
@@ -91,4 +93,3 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 ## [v0.1.0](https://github.com/awadell1/PkgJogger.jl/releases/tag/v0.1.0) - 2021-08-14
 
 - Initial release.
-

--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ NVTX = "5da4648a-3479-48b8-97b9-01cb529c0a1f"
 PkgJoggerCUDAExt = ["CUDA", "NVTX"]
 
 [compat]
-BSON = "0.3"
+BSON = "0.3.4"
 BenchmarkTools = "1.5"
 CUDA = "5"
 CodecZlib = "0.7"


### PR DESCRIPTION
- Revise: lowered minimum to 3.3 (3.2 fails precompile on Julia 1.9); compat allows all 3.x
- BSON: lowered minimum to 0.3.4 (0.3.3 fails on Julia ≥1.7 due to DataType.mutable); compat allows <0.4

Validated via Test Min Compat Bounds job:
- Failing configs: Revise=3.2, BSON=0.3.3
- Passing configs: Revise=3.3, BSON=0.3.4

RC jobs still flaky/unrelated to min-compat.
